### PR TITLE
[AIRFLOW-1028] Databricks Operator for Airflow

### DIFF
--- a/airflow/contrib/example_dags/example_databricks_operator.py
+++ b/airflow/contrib/example_dags/example_databricks_operator.py
@@ -32,7 +32,7 @@ dag = DAG(
 
 NEW_CLUSTER_SPEC = {
     'spark_version': '2.0.x-scala2.10',
-    'node_type_id': 'r3.xlarge',
+    'node_type_id': 'memory-optimized',
     'aws_attributes': {
         'availability': 'ON_DEMAND'
     },

--- a/airflow/contrib/example_dags/example_databricks_operator.py
+++ b/airflow/contrib/example_dags/example_databricks_operator.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import airflow
+
+from airflow import DAG
+from airflow.contrib.operators.databricks_operator import DatabricksSubmitRunOperator
+from datetime import datetime, timedelta
+
+
+args = {
+    'owner': 'airflow',
+    'email': ['airflow@airflow.com'],
+    'depends_on_past': False,
+    'start_date': airflow.utils.dates.days_ago(2)
+}
+
+dag = DAG(
+    dag_id='example_databricks_operator', default_args=args,
+    schedule_interval='@daily')
+
+NEW_CLUSTER_SPEC = {
+    'spark_version': '2.0.x-scala2.10',
+    'node_type_id': 'r3.xlarge',
+    'aws_attributes': {
+        'availability': 'ON_DEMAND'
+    },
+    'num_workers': 8
+}
+
+notebook_task_params = {
+    'new_cluster': NEW_CLUSTER_SPEC,
+    'notebook_task': {
+        'notebook_path': '/test',
+    },
+}
+notebook_task = DatabricksSubmitRunOperator(
+    task_id='notebook_task',
+    dag=dag,
+    **notebook_task_params)
+
+spark_jar_task_params = {
+    'new_cluster': NEW_CLUSTER_SPEC,
+    'spark_jar_task': {
+        'main_class_name': 'com.databricks.ComputeModels'
+    },
+    'libraries': [
+        {
+            'jar': 'dbfs:/my-jar.jar'
+        },
+    ]
+}
+spark_jar_task = DatabricksSubmitRunOperator(
+    task_id='spark_jar_task',
+    dag=dag,
+    **spark_jar_task_params)
+
+notebook_task.set_downstream(spark_jar_task)

--- a/airflow/contrib/example_dags/example_databricks_operator.py
+++ b/airflow/contrib/example_dags/example_databricks_operator.py
@@ -31,7 +31,7 @@ dag = DAG(
     schedule_interval='@daily')
 
 NEW_CLUSTER_SPEC = {
-    'spark_version': '2.0.x-scala2.10',
+    'spark_version': '2.1.0-db3-scala2.11',
     'node_type_id': 'r3.xlarge',
     'aws_attributes': {
         'availability': 'ON_DEMAND'

--- a/airflow/contrib/example_dags/example_databricks_operator.py
+++ b/airflow/contrib/example_dags/example_databricks_operator.py
@@ -32,7 +32,7 @@ dag = DAG(
 
 NEW_CLUSTER_SPEC = {
     'spark_version': '2.0.x-scala2.10',
-    'node_type_id': 'memory-optimized',
+    'node_type_id': 'r3.xlarge',
     'aws_attributes': {
         'availability': 'ON_DEMAND'
     },

--- a/airflow/contrib/hooks/databricks_hook.py
+++ b/airflow/contrib/hooks/databricks_hook.py
@@ -62,6 +62,13 @@ class DatabricksHook(BaseHook):
             return host
 
     def _do_api_call(self, endpoint_info, api_parameters):
+        """
+        Utility function to perform an API call with retries
+        :param endpoint_info: Tuple of method and endpoint
+        :type endpoint_info: (string, string)
+        :param api_parameters: Parameters for this API call.
+        :type api_parameters: string
+        """
         method, endpoint = endpoint_info
         url = 'https://{host}/{endpoint}'.format(
             host=self._parse_host(self.databricks_conn.host),
@@ -133,6 +140,9 @@ class DatabricksHook(BaseHook):
 
 
 class RunState:
+    """
+    Utility class for the run state concept of Databricks runs.
+    """
     def __init__(self, life_cycle_state, result_state, state_message):
         self.life_cycle_state = life_cycle_state
         self.result_state = result_state

--- a/airflow/contrib/hooks/databricks_hook.py
+++ b/airflow/contrib/hooks/databricks_hook.py
@@ -22,13 +22,17 @@ from airflow.hooks.base_hook import BaseHook
 
 SUBMIT_RUN_ENDPOINT = ('POST', 'api/2.0/jobs/runs/submit')
 GET_RUN_ENDPOINT = ('GET', 'api/2.0/jobs/runs/get')
-USER_AGENT_HEADER = {'user-agent': 'airflow-{v}'.format(v = __version__)}
+USER_AGENT_HEADER = {'user-agent': 'airflow-{v}'.format(v=__version__)}
+
 
 class DatabricksHook(BaseHook):
     """
     Interact with Databricks.
     """
-    def __init__(self, databricks_conn_id='databricks_default', timeout_seconds=60, retry_limit=3):
+    def __init__(self,
+                 databricks_conn_id='databricks_default',
+                 timeout_seconds=60,
+                 retry_limit=3):
         self.databricks_conn_id = databricks_conn_id
         self.databricks_conn = self.get_connection(databricks_conn_id)
         self.timeout_seconds = timeout_seconds
@@ -36,8 +40,9 @@ class DatabricksHook(BaseHook):
 
     def _do_api_call(self, endpoint_info, api_parameters):
         method, endpoint = endpoint_info
-        url = 'https://{host}/{endpoint}'.format(host=self.databricks_conn.host,
-                                                 endpoint=endpoint)
+        url = 'https://{host}/{endpoint}'.format(
+                host=self.databricks_conn.host,
+                endpoint=endpoint)
         auth = (self.databricks_conn.login, self.databricks_conn.password)
         if method == 'GET':
             request_func = requests.get
@@ -102,6 +107,7 @@ class DatabricksHook(BaseHook):
         response = self._do_api_call(GET_RUN_ENDPOINT, api_params)
         return RunState.from_get_run_response(response)
 
+
 class RunState:
     def __init__(self, life_cycle_state, result_state, state_message):
         self.life_cycle_state = life_cycle_state
@@ -122,6 +128,7 @@ class RunState:
         return self.life_cycle_state == 'TERMINATED' or \
                self.life_cycle_state == 'SKIPPED' or \
                self.life_cycle_state == 'INTERNAL_ERROR'
+
     @property
     def is_successful(self):
         return self.result_state is not None and self.result_state == 'SUCCESS'

--- a/airflow/contrib/hooks/databricks_hook.py
+++ b/airflow/contrib/hooks/databricks_hook.py
@@ -1,0 +1,113 @@
+import logging
+import requests
+
+from airflow import __version__
+from airflow.exceptions import AirflowException
+from airflow.hooks.base_hook import BaseHook
+
+SUBMIT_RUN_ENDPOINT = ('POST', 'api/2.0/jobs/runs/submit')
+GET_RUN_ENDPOINT = ('GET', 'api/2.0/jobs/runs/get')
+USER_AGENT_HEADER = {'user-agent': 'airflow-{v}'.format(v = __version__)}
+
+class DatabricksHook(BaseHook):
+    """
+    Interact with Databricks.
+    """
+    def __init__(self, databricks_conn_id='databricks_default', timeout_seconds=60, retry_limit=3):
+        self.databricks_conn_id = databricks_conn_id
+        self.databricks_conn = self.get_connection(databricks_conn_id)
+        self.timeout_seconds = timeout_seconds
+        self.retry_limit = retry_limit
+
+    def _do_api_call(self, endpoint_info, api_parameters):
+        method, endpoint = endpoint_info
+        url = 'https://{host}/{endpoint}'.format(host=self.databricks_conn.host,
+                                                 endpoint=endpoint)
+        auth = (self.databricks_conn.login, self.databricks_conn.password)
+        if method == 'GET':
+            request_func = requests.get
+        elif method == 'POST':
+            request_func = requests.post
+        else:
+            raise AirflowException('Unexpected HTTP Method')
+
+        for _ in range(self.retry_limit):
+            attempt_num = _ + 1
+            try:
+                response = request_func(url,
+                                        json=api_parameters,
+                                        auth=auth,
+                                        headers=USER_AGENT_HEADER,
+                                        timeout=self.timeout_seconds,
+                                        verify=False)
+                if response.status_code == 404:
+                    raise AirflowException(response.content)
+                else:
+                    return response.json()
+            except Exception as e:
+                logging.error('Attempt {0} API Request to Databricks failed ' +
+                              'with reason: {1}'.format(attempt_num, e))
+        raise AirflowException('API requests to Databricks failed {} times. ' +
+                               'Giving up.'.format(self.retry_limit))
+
+    def submit_run(self,
+                   spark_jar_task=None,
+                   notebook_task=None,
+                   new_cluster=None,
+                   existing_cluster_id=None,
+                   libraries=[],
+                   run_name=None,
+                   timeout_seconds=0,
+                   **kwargs):
+        api_params = kwargs.copy()
+        if spark_jar_task is not None:
+            api_params['spark_jar_task'] = spark_jar_task
+        if notebook_task is not None:
+            api_params['notebook_task'] = notebook_task
+        if new_cluster is not None:
+            api_params['new_cluster'] = new_cluster
+        if existing_cluster_id is not None:
+            api_params['existing_cluster_id'] = existing_cluster_id
+        api_params['libraries'] = libraries
+        if run_name is not None:
+            api_params['run_name'] = run_name
+        api_params['timeout_seconds'] = timeout_seconds
+        response = self._do_api_call(SUBMIT_RUN_ENDPOINT, api_params)
+        return response['run_id']
+
+    def get_run_page_url(self, run_id):
+        api_params = {'run_id': run_id}
+        response = self._do_api_call(GET_RUN_ENDPOINT, api_params)
+        return response['run_page_url']
+
+    def get_run_state(self, run_id):
+        api_params = {'run_id': run_id}
+        response = self._do_api_call(GET_RUN_ENDPOINT, api_params)
+        return RunState.from_get_run_response(response)
+
+class RunState:
+    def __init__(self, life_cycle_state, result_state, state_message):
+        self.life_cycle_state = life_cycle_state
+        self.result_state = result_state
+        self.state_message = state_message
+
+    @classmethod
+    def from_get_run_response(cls, response):
+        life_cycle_state = response['state']['life_cycle_state']
+        # result_state may not be in the state if not terminal
+        result_state = response['state'].get('result_state', None)
+        state_message = response['state']['state_message']
+
+        return cls(life_cycle_state, result_state, state_message)
+
+    @property
+    def is_terminal(self):
+        return self.life_cycle_state == 'TERMINATED' or \
+               self.life_cycle_state == 'SKIPPED' or \
+               self.life_cycle_state == 'INTERNAL_ERROR'
+    @property
+    def is_successful(self):
+        return self.result_state is not None and self.result_state == 'SUCCESS'
+
+    def __repr__(self):
+        return str(self.__dict__)

--- a/airflow/contrib/hooks/databricks_hook.py
+++ b/airflow/contrib/hooks/databricks_hook.py
@@ -64,25 +64,25 @@ class DatabricksHook(BaseHook):
     def _do_api_call(self, endpoint_info, api_parameters):
         method, endpoint = endpoint_info
         url = 'https://{host}/{endpoint}'.format(
-                host=self._parse_host(self.databricks_conn.host),
-                endpoint=endpoint)
+            host=self._parse_host(self.databricks_conn.host),
+            endpoint=endpoint)
         auth = (self.databricks_conn.login, self.databricks_conn.password)
         if method == 'GET':
             request_func = requests.get
         elif method == 'POST':
             request_func = requests.post
         else:
-            raise AirflowException('Unexpected HTTP Method')
+            raise AirflowException('Unexpected HTTP Method: ' + method)
 
-        for _ in range(self.retry_limit):
-            attempt_num = _ + 1
+        for attempt_num in range(1, self.retry_limit+1):
             try:
-                response = request_func(url,
-                                        json=api_parameters,
-                                        auth=auth,
-                                        headers=USER_AGENT_HEADER,
-                                        timeout=self.timeout_seconds,
-                                        verify=False)
+                response = request_func(
+                    url,
+                    json=api_parameters,
+                    auth=auth,
+                    headers=USER_AGENT_HEADER,
+                    timeout=self.timeout_seconds,
+                    verify=False)
                 if response.status_code == 200:
                     return response.json()
                 else:

--- a/airflow/contrib/hooks/databricks_hook.py
+++ b/airflow/contrib/hooks/databricks_hook.py
@@ -83,12 +83,12 @@ class DatabricksHook(BaseHook):
                                         headers=USER_AGENT_HEADER,
                                         timeout=self.timeout_seconds,
                                         verify=False)
-                if response.status_code == 404:
+                if response.status_code == 200:
+                    return response.json()
+                else:
                     # In this case, the user probably made a mistake.
                     # Don't retry.
                     raise AirflowException(response.content)
-                else:
-                    return response.json()
             except (ConnectionError, Timeout) as e:
                 logging.error(('Attempt {0} API Request to Databricks failed ' +
                               'with reason: {1}').format(attempt_num, e))

--- a/airflow/contrib/hooks/databricks_hook.py
+++ b/airflow/contrib/hooks/databricks_hook.py
@@ -155,7 +155,7 @@ class RunState:
 
     @property
     def is_successful(self):
-        return self.result_state is not None and self.result_state == 'SUCCESS'
+        return self.result_state == 'SUCCESS'
 
     def __eq__(self, other):
         return self.life_cycle_state == other.life_cycle_state and \

--- a/airflow/contrib/hooks/databricks_hook.py
+++ b/airflow/contrib/hooks/databricks_hook.py
@@ -93,7 +93,6 @@ class DatabricksHook(BaseHook):
                 if response.status_code == 200:
                     return response.json()
                 else:
-                    print response.status_code
                     # In this case, the user probably made a mistake.
                     # Don't retry.
                     raise AirflowException(response.content)

--- a/airflow/contrib/hooks/databricks_hook.py
+++ b/airflow/contrib/hooks/databricks_hook.py
@@ -1,3 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import logging
 import requests
 
@@ -41,6 +56,8 @@ class DatabricksHook(BaseHook):
                                         timeout=self.timeout_seconds,
                                         verify=False)
                 if response.status_code == 404:
+                    # In this case, the user probably made a mistake.
+                    # Don't retry.
                     raise AirflowException(response.content)
                 else:
                     return response.json()
@@ -108,6 +125,11 @@ class RunState:
     @property
     def is_successful(self):
         return self.result_state is not None and self.result_state == 'SUCCESS'
+
+    def __eq__(self, other):
+        return self.life_cycle_state == other.life_cycle_state and \
+               self.result_state == other.result_state and \
+               self.state_message == other.state_message
 
     def __repr__(self):
         return str(self.__dict__)

--- a/airflow/contrib/operators/databricks_operator.py
+++ b/airflow/contrib/operators/databricks_operator.py
@@ -105,7 +105,8 @@ class DatabricksSubmitRunOperator(BaseOperator):
         elif param_a is None and param_b is not None:
             pass
         else:
-            raise AirflowException
+            raise AirflowException(('It is an error to provide both {0} and {1}. ' +
+                'Please select only one').format(param_a, param_b))
 
     def _log_run_page_url(self, url):
         logging.info('View run status, Spark UI, and logs at {}.'.format(url))

--- a/airflow/contrib/operators/databricks_operator.py
+++ b/airflow/contrib/operators/databricks_operator.py
@@ -115,14 +115,15 @@ class DatabricksSubmitRunOperator(BaseOperator):
 
     def execute(self, context):
         hook = self.get_hook()
-        run_id = hook.submit_run(self.spark_jar_task,
-                                 self.notebook_task,
-                                 self.new_cluster,
-                                 self.existing_cluster_id,
-                                 self.libraries,
-                                 self.run_name,
-                                 self.timeout_seconds,
-                                 **self.extra_api_parameters)
+        run_id = hook.submit_run(
+            self.spark_jar_task,
+            self.notebook_task,
+            self.new_cluster,
+            self.existing_cluster_id,
+            self.libraries,
+            self.run_name,
+            self.timeout_seconds,
+            **self.extra_api_parameters)
         run_page_url = hook.get_run_page_url(run_id)
         logging.info(LINE_BREAK)
         logging.info('Run submitted with run_id: {}'.format(run_id))

--- a/airflow/contrib/operators/databricks_operator.py
+++ b/airflow/contrib/operators/databricks_operator.py
@@ -29,6 +29,72 @@ class DatabricksSubmitRunOperator(BaseOperator):
     Submits an ephemeral run to Databricks.
 
     https://docs.databricks.com/api/latest/jobs.html#runs-submit
+
+    Note that the named
+    parameters to this operator match the parameters exposed by
+    the Databricks ``api/2.0/jobs/runs/submit`` endpoint.
+
+    As a result, one way to instantiate a ``DatabricksSubmitRunOperator``
+    is to pass the same JSON object used to call ``api/2.0/jobs/runs/submit``
+    into the ``DatabricksSubmitRunOperator``. For example: ::
+
+        params = {
+          "new_cluster": {
+            "spark_version": "2.0.x-scala2.10",
+            "node_type_id": "r3.xlarge",
+            "aws_attributes": {
+              "availability": "ON_DEMAND"
+            },
+            "num_workers": 2
+          },
+          "libraries": [
+            {
+              "jar": "dbfs:/test.jar"
+            },
+            {
+              "maven": {
+                "coordinates": "org.jsoup:jsoup:1.7.2"
+              }
+            }
+          ],
+          "spark_jar_task": {
+            "main_class_name": "com.databricks.ComputeModels"
+          }
+        }
+        DatabricksSubmitRunOperator(task_id='spark_jar_run', **params)
+
+    :param spark_jar_task: The main class and parameters for the JAR task. Note that
+        the actual JAR is specified in the ``libraries``.
+        *EITHER* ``spark_jar_task`` *OR* ``notebook_task`` should be specified.
+        https://docs.databricks.com/api/latest/jobs.html#jobssparkjartask
+    :type spark_jar_task: dict
+    :param notebook_task: The notebook path and parameters for the notebook task.
+        *EITHER* ``spark_jar_task`` *OR* ``notebook_task`` should be specified.
+        https://docs.databricks.com/api/latest/jobs.html#jobsnotebooktask
+    :type notebook_task: dict
+    :param new_cluster: Specs for a new cluster on which this task will be run.
+        *EITHER* ``new_cluster`` *OR* ``existing_cluster_id`` should be specified.
+        https://docs.databricks.com/api/latest/jobs.html#jobsclusterspecnewcluster
+    :type new_cluster: dict
+    :param existing_cluster_id: ID for existing cluster on which to run this task.
+        *EITHER* ``new_cluster`` *OR* ``existing_cluster_id`` should be specified.
+    :type existing_cluster_id: string
+    :param libraries: Libraries which this run will use.
+        https://docs.databricks.com/api/latest/libraries.html#managedlibrarieslibrary
+    :type libraries: list of dicts
+    :param run_name: The run name used for this task.
+        By default this will be set to the ``task_id``.
+    :type run_name: string
+    :param timeout_seconds: The timeout for this run. By default a value of 0 is used which
+        means to have no timeout.
+    :type timeout_seconds: int32
+    :param extra_api_parameters: Extra parameters which will be merged with parameters listed
+        above. This may be used if additional features are added to the ``api/2.0/jobs/runs/submit``
+        endpoint.
+    :type extra_api_parameters: dict
+    :param databricks_conn_id: The name of the connection to use.
+        By default and in the common case this will be ``databricks_default``.
+    :type databricks_conn_id: string
     """
     ui_color = '#1CB1C2'
     ui_fgcolor = '#fff'
@@ -46,71 +112,7 @@ class DatabricksSubmitRunOperator(BaseOperator):
             databricks_conn_id='databricks_default',
             **kwargs):
         """
-        Creates a new ``DatabricksSubmitRunOperator``. Note that the named
-        parameters to this operator match the parameters exposed by
-        the Databricks ``api/2.0/jobs/runs/submit`` endpoint.
-
-        As a result, one way to instantiate a ``DatabricksSubmitRunOperator``
-        is to pass the same JSON object used to call ``api/2.0/jobs/runs/submit``
-        into the ``DatabricksSubmitRunOperator``. For example: ::
-
-            params = {
-              "new_cluster": {
-                "spark_version": "2.0.x-scala2.10",
-                "node_type_id": "r3.xlarge",
-                "aws_attributes": {
-                  "availability": "ON_DEMAND"
-                },
-                "num_workers": 2
-              },
-              "libraries": [
-                {
-                  "jar": "dbfs:/test.jar"
-                },
-                {
-                  "maven": {
-                    "coordinates": "org.jsoup:jsoup:1.7.2"
-                  }
-                }
-              ],
-              "spark_jar_task": {
-                "main_class_name": "com.databricks.ComputeModels"
-              }
-            }
-            DatabricksSubmitRunOperator(task_id='spark_jar_run', **params)
-
-        :param spark_jar_task: The main class and parameters for the JAR task. Note that
-            the actual JAR is specified in the ``libraries``.
-            *EITHER* ``spark_jar_task`` *OR* ``notebook_task`` should be specified.
-            https://docs.databricks.com/api/latest/jobs.html#jobssparkjartask
-        :type spark_jar_task: dict
-        :param notebook_task: The notebook path and parameters for the notebook task.
-            *EITHER* ``spark_jar_task`` *OR* ``notebook_task`` should be specified.
-            https://docs.databricks.com/api/latest/jobs.html#jobsnotebooktask
-        :type notebook_task: dict
-        :param new_cluster: Specs for a new cluster on which this task will be run.
-            *EITHER* ``new_cluster`` *OR* ``existing_cluster_id`` should be specified.
-            https://docs.databricks.com/api/latest/jobs.html#jobsclusterspecnewcluster
-        :type new_cluster: dict
-        :param existing_cluster_id: ID for existing cluster on which to run this task.
-            *EITHER* ``new_cluster`` *OR* ``existing_cluster_id`` should be specified.
-        :type existing_cluster_id: string
-        :param libraries: Libraries which this run will use.
-            https://docs.databricks.com/api/latest/libraries.html#managedlibrarieslibrary
-        :type libraries: list of dicts
-        :param run_name: The run name used for this task.
-            By default this will be set to the ``task_id``.
-        :type run_name: string
-        :param timeout_seconds: The timeout for this run. By default a value of 0 is used which
-            means to have no timeout.
-        :type timeout_seconds: int32
-        :param extra_api_parameters: Extra parameters which will be merged with parameters listed
-            above. This may be used if additional features are added to the ``api/2.0/jobs/runs/submit``
-            endpoint.
-        :type extra_api_parameters: dict
-        :param databricks_conn_id: The name of the connection to use.
-            By default and in the common case this will be ``databricks_default``.
-        :type databricks_conn_id: string
+        Creates a new ``DatabricksSubmitRunOperator``.
         """
         super(DatabricksSubmitRunOperator, self).__init__(**kwargs)
         self.spark_jar_task = spark_jar_task

--- a/airflow/contrib/operators/databricks_operator.py
+++ b/airflow/contrib/operators/databricks_operator.py
@@ -82,6 +82,35 @@ class DatabricksSubmitRunOperator(BaseOperator):
         }
         DatabricksSubmitRunOperator(task_id='run-1', **params)
         ```
+
+        :param spark_jar_task: The main class and parameters for the jar task. The jar is specified in libraries.
+            EITHER spark_jar_task OR notebook_task should be specified
+            See https://docs.databricks.com/api/latest/jobs.html#jobssparkjartask
+        :type spark_jar_task: dict
+        :param notebook_task: The notebook path and parameters for the notebook task.
+            EITHER spark_jar_task OR notebook_task should be specified
+            See https://docs.databricks.com/api/latest/jobs.html#jobsnotebooktask
+        :type notebook_task: dict
+        :param new_cluster: Specs for a new cluster on which this task will be run.
+            EITHER new_cluster OR existing_cluster_id should be specified
+            See https://docs.databricks.com/api/latest/jobs.html#jobsclusterspecnewcluster
+        :type new_cluster: dict
+        :param existing_cluster_id: ID for existing cluster on which to run this task.
+            EITHER new_cluster OR existing_cluster_id should be specified
+        :type existing_cluster_id: string
+        :param libraries: Libraries which this run will use.
+            See https://docs.databricks.com/api/latest/libraries.html#managedlibrarieslibrary
+        :type libraries: list of dicts
+        :param run_name: The run name used for this task. By default this will be set to the task_id.
+        :type run_name: string
+        :param timeout_seconds: The timeout for this run. By default a value of 0 is used which
+            means to have no timeout.
+        :type timeout_seconds: int32
+        :param extra_api_parameters: Extra parameters which will be merged with parameters listed
+            above. This may be used if additional features are added to the submit run endpoint.
+        :type extra_api_parameters: dict
+        :param databricks_conn_id: Name of the connection to use.
+        :type extra_api_parameters: string
         """
         super(DatabricksSubmitRunOperator, self).__init__(**kwargs)
         self.spark_jar_task = spark_jar_task
@@ -96,10 +125,16 @@ class DatabricksSubmitRunOperator(BaseOperator):
         self._validate_parameters()
 
     def _validate_parameters(self):
+        """
+        Validates the parameters provided to this operator.
+        """
         self._validate_oneof(self.spark_jar_task, self.notebook_task)
         self._validate_oneof(self.new_cluster, self.existing_cluster_id)
 
     def _validate_oneof(self, param_a, param_b):
+        """
+        Ensures either param_a XOR param_b is set.
+        """
         if param_a is not None and param_b is None:
             pass
         elif param_a is None and param_b is not None:

--- a/airflow/contrib/operators/databricks_operator.py
+++ b/airflow/contrib/operators/databricks_operator.py
@@ -32,6 +32,9 @@ class DatabricksSubmitRunOperator(BaseOperator):
     For more information about Databricks ephemeral runs look at
     https://docs.databricks.com/api/latest/jobs.html#runs-submit
     """
+    ui_color = '#1CB1C2'
+    ui_fgcolor = '#fff'
+
     def __init__(self,
                  spark_jar_task=None,
                  notebook_task=None,

--- a/airflow/contrib/operators/databricks_operator.py
+++ b/airflow/contrib/operators/databricks_operator.py
@@ -1,0 +1,88 @@
+import logging
+import time
+
+from airflow.exceptions import AirflowException
+from airflow.contrib.hooks.databricks_hook import DatabricksHook
+from airflow.models import BaseOperator
+
+POLL_SLEEP_PERIOD_SECONDS = 5
+HR = ("-" * 80)
+
+class DatabricksSubmitRunOperator(BaseOperator):
+    """
+    Submits an ephemeral run to Databricks and waits
+    for it to terminate successfully.
+    """
+    def __init__(self,
+                 spark_jar_task=None,
+                 notebook_task=None,
+                 new_cluster=None,
+                 existing_cluster_id=None,
+                 libraries=[],
+                 run_name=None,
+                 timeout_seconds=0,
+                 extra_api_parameters={},
+                 databricks_conn_id='databricks_default',
+                 **kwargs):
+        super(DatabricksSubmitRunOperator, self).__init__(**kwargs)
+        self.spark_jar_task = spark_jar_task
+        self.notebook_task = notebook_task
+        self.new_cluster = new_cluster
+        self.existing_cluster_id = existing_cluster_id
+        self.libraries = libraries
+        self.run_name = task_id if run_name is None else run_name
+        self.timeout_seconds = timeout_seconds
+        self.extra_api_parameters = extra_api_parameters
+        self.databricks_conn_id = databricks_conn_id
+        self._validate_parameters()
+
+    def _validate_parameters(self):
+        self._validate_oneof(self.spark_jar_task, self.notebook_task)
+        self._validate_oneof(self.new_cluster, self.existing_cluster_id)
+
+    def _validate_oneof(self, param_a, param_b):
+        if param_a is not None and param_b is None:
+            pass
+        elif param_a is None and param_b is not None:
+            pass
+        else:
+            raise AirflowException
+
+    def _log_run_page_url(self, url):
+        logging.info('View run status, Spark UI, and logs at {}.'.format(url))
+
+    def get_hook(self):
+        return DatabricksHook(self.databricks_conn_id)
+
+    def execute(self, context):
+        hook = self.get_hook()
+        run_id = hook.submit_run(self.spark_jar_task,
+                                 self.notebook_task,
+                                 self.new_cluster,
+                                 self.existing_cluster_id,
+                                 self.libraries,
+                                 self.run_name,
+                                 self.timeout_seconds,
+                                 **self.extra_api_parameters)
+        run_page_url = hook.get_run_page_url(run_id)
+        logging.info(HR)
+        logging.info('Run submitted with run_id: {}'.format(run_id))
+        self._log_run_page_url(run_page_url)
+        logging.info(HR)
+        while True:
+            run_state = hook.get_run_state(run_id)
+            if run_state.is_terminal:
+                if run_state.is_successful:
+                    logging.info('{} completed successfully.'.format(self.task_id))
+                    self._log_run_page_url(run_page_url)
+                    return
+                else:
+                    error_message = '{t} failed with terminal state: {s}'.format(t=self.task_id,
+                                                                                 s=run_state)
+                    raise AirflowException(error_message)
+            else:
+                logging.info('{t} in run state: {s}'.format(t=self.task_id,
+                                                            s=run_state))
+                self._log_run_page_url(run_page_url)
+                logging.info('Sleeping for {} seconds.'.format(POLL_SLEEP_PERIOD_SECONDS))
+                time.sleep(POLL_SLEEP_PERIOD_SECONDS)

--- a/airflow/contrib/operators/databricks_operator.py
+++ b/airflow/contrib/operators/databricks_operator.py
@@ -35,17 +35,18 @@ class DatabricksSubmitRunOperator(BaseOperator):
     ui_color = '#1CB1C2'
     ui_fgcolor = '#fff'
 
-    def __init__(self,
-                 spark_jar_task=None,
-                 notebook_task=None,
-                 new_cluster=None,
-                 existing_cluster_id=None,
-                 libraries=[],
-                 run_name=None,
-                 timeout_seconds=0,
-                 extra_api_parameters={},
-                 databricks_conn_id='databricks_default',
-                 **kwargs):
+    def __init__(
+            self,
+            spark_jar_task=None,
+            notebook_task=None,
+            new_cluster=None,
+            existing_cluster_id=None,
+            libraries=[],
+            run_name=None,
+            timeout_seconds=0,
+            extra_api_parameters={},
+            databricks_conn_id='databricks_default',
+            **kwargs):
         """
         Create a new `DatabricksSubmitRunOperator`. Note that the named
         parameters to this operator match the parameters exposed by
@@ -137,8 +138,8 @@ class DatabricksSubmitRunOperator(BaseOperator):
                     return
                 else:
                     error_message = '{t} failed with terminal state: {s}'.format(
-                                    t=self.task_id,
-                                    s=run_state)
+                            t=self.task_id,
+                            s=run_state)
                     raise AirflowException(error_message)
             else:
                 logging.info('{t} in run state: {s}'.format(t=self.task_id,

--- a/airflow/contrib/operators/databricks_operator.py
+++ b/airflow/contrib/operators/databricks_operator.py
@@ -144,7 +144,7 @@ class DatabricksSubmitRunOperator(BaseOperator):
                 'Please select only one').format(param_a, param_b))
 
     def _log_run_page_url(self, url):
-        logging.info('View run status, Spark UI, and logs at {}.'.format(url))
+        logging.info('View run status, Spark UI, and logs at {}'.format(url))
 
     def get_hook(self):
         return DatabricksHook(self.databricks_conn_id)

--- a/airflow/contrib/operators/databricks_operator.py
+++ b/airflow/contrib/operators/databricks_operator.py
@@ -26,10 +26,8 @@ LINE_BREAK = ("-" * 80)
 
 class DatabricksSubmitRunOperator(BaseOperator):
     """
-    Submits an ephemeral run to Databricks and waits for it to complete
-    successfully.
+    Submits an ephemeral run to Databricks.
 
-    For more information about Databricks ephemeral runs look at
     https://docs.databricks.com/api/latest/jobs.html#runs-submit
     """
     ui_color = '#1CB1C2'
@@ -48,69 +46,71 @@ class DatabricksSubmitRunOperator(BaseOperator):
             databricks_conn_id='databricks_default',
             **kwargs):
         """
-        Create a new `DatabricksSubmitRunOperator`. Note that the named
+        Creates a new ``DatabricksSubmitRunOperator``. Note that the named
         parameters to this operator match the parameters exposed by
-        `api/2.0/runs/submit`.
+        the Databricks ``api/2.0/jobs/runs/submit`` endpoint.
 
-        As a result, one way to instantiate a `DatabricksSubmitRunOperator`
-        is to pass the same JSON object used to call `api/2.0/runs/submit`
-        into the `DatabricksSubmitRunOperator`. For example:
+        As a result, one way to instantiate a ``DatabricksSubmitRunOperator``
+        is to pass the same JSON object used to call ``api/2.0/jobs/runs/submit``
+        into the ``DatabricksSubmitRunOperator``. For example: ::
 
-        ```
-        params = {
-          "new_cluster": {
-            "spark_version": "2.0.x-scala2.10",
-            "node_type_id": "r3.xlarge",
-            "aws_attributes": {
-              "availability": "ON_DEMAND"
-            },
-            "num_workers": 2
-          },
-          "libraries": [
-            {
-              "jar": "dbfs:/test.jar"
-            },
-            {
-              "maven": {
-                "coordinates": "org.jsoup:jsoup:1.7.2"
+            params = {
+              "new_cluster": {
+                "spark_version": "2.0.x-scala2.10",
+                "node_type_id": "r3.xlarge",
+                "aws_attributes": {
+                  "availability": "ON_DEMAND"
+                },
+                "num_workers": 2
+              },
+              "libraries": [
+                {
+                  "jar": "dbfs:/test.jar"
+                },
+                {
+                  "maven": {
+                    "coordinates": "org.jsoup:jsoup:1.7.2"
+                  }
+                }
+              ],
+              "spark_jar_task": {
+                "main_class_name": "com.databricks.ComputeModels"
               }
             }
-          ],
-          "spark_jar_task": {
-            "main_class_name": "com.databricks.ComputeModels"
-          }
-        }
-        DatabricksSubmitRunOperator(task_id='run-1', **params)
-        ```
+            DatabricksSubmitRunOperator(task_id='spark_jar_run', **params)
 
-        :param spark_jar_task: The main class and parameters for the jar task. The jar is specified in libraries.
-            EITHER spark_jar_task OR notebook_task should be specified
-            See https://docs.databricks.com/api/latest/jobs.html#jobssparkjartask
+        :param spark_jar_task: The main class and parameters for the JAR task. Note that
+            the actual JAR is specified in the ``libraries``.
+            *EITHER* ``spark_jar_task`` *OR* ``notebook_task`` should be specified.
+            https://docs.databricks.com/api/latest/jobs.html#jobssparkjartask
         :type spark_jar_task: dict
         :param notebook_task: The notebook path and parameters for the notebook task.
-            EITHER spark_jar_task OR notebook_task should be specified
-            See https://docs.databricks.com/api/latest/jobs.html#jobsnotebooktask
+            *EITHER* ``spark_jar_task`` *OR* ``notebook_task`` should be specified.
+            https://docs.databricks.com/api/latest/jobs.html#jobsnotebooktask
         :type notebook_task: dict
         :param new_cluster: Specs for a new cluster on which this task will be run.
-            EITHER new_cluster OR existing_cluster_id should be specified
-            See https://docs.databricks.com/api/latest/jobs.html#jobsclusterspecnewcluster
+            *EITHER* ``new_cluster`` *OR* ``existing_cluster_id`` should be specified.
+            https://docs.databricks.com/api/latest/jobs.html#jobsclusterspecnewcluster
         :type new_cluster: dict
         :param existing_cluster_id: ID for existing cluster on which to run this task.
-            EITHER new_cluster OR existing_cluster_id should be specified
+            *EITHER* ``new_cluster`` *OR* ``existing_cluster_id`` should be specified.
         :type existing_cluster_id: string
         :param libraries: Libraries which this run will use.
-            See https://docs.databricks.com/api/latest/libraries.html#managedlibrarieslibrary
+            https://docs.databricks.com/api/latest/libraries.html#managedlibrarieslibrary
         :type libraries: list of dicts
-        :param run_name: The run name used for this task. By default this will be set to the task_id.
+        :param run_name: The run name used for this task.
+            By default this will be set to the ``task_id``.
         :type run_name: string
         :param timeout_seconds: The timeout for this run. By default a value of 0 is used which
             means to have no timeout.
         :type timeout_seconds: int32
         :param extra_api_parameters: Extra parameters which will be merged with parameters listed
-            above. This may be used if additional features are added to the submit run endpoint.
+            above. This may be used if additional features are added to the ``api/2.0/jobs/runs/submit``
+            endpoint.
         :type extra_api_parameters: dict
-        :param databricks_conn_id: Name of the connection to use.
-        :type extra_api_parameters: string
+        :param databricks_conn_id: The name of the connection to use.
+            By default and in the common case this will be ``databricks_default``.
+        :type databricks_conn_id: string
         """
         super(DatabricksSubmitRunOperator, self).__init__(**kwargs)
         self.spark_jar_task = spark_jar_task

--- a/airflow/contrib/operators/databricks_operator.py
+++ b/airflow/contrib/operators/databricks_operator.py
@@ -1,3 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import logging
 import time
 
@@ -6,7 +21,7 @@ from airflow.contrib.hooks.databricks_hook import DatabricksHook
 from airflow.models import BaseOperator
 
 POLL_SLEEP_PERIOD_SECONDS = 5
-HR = ("-" * 80)
+LINE_BREAK = ("-" * 80)
 
 class DatabricksSubmitRunOperator(BaseOperator):
     """
@@ -30,7 +45,7 @@ class DatabricksSubmitRunOperator(BaseOperator):
         self.new_cluster = new_cluster
         self.existing_cluster_id = existing_cluster_id
         self.libraries = libraries
-        self.run_name = task_id if run_name is None else run_name
+        self.run_name = kwargs['task_id'] if run_name is None else run_name
         self.timeout_seconds = timeout_seconds
         self.extra_api_parameters = extra_api_parameters
         self.databricks_conn_id = databricks_conn_id
@@ -65,10 +80,10 @@ class DatabricksSubmitRunOperator(BaseOperator):
                                  self.timeout_seconds,
                                  **self.extra_api_parameters)
         run_page_url = hook.get_run_page_url(run_id)
-        logging.info(HR)
+        logging.info(LINE_BREAK)
         logging.info('Run submitted with run_id: {}'.format(run_id))
         self._log_run_page_url(run_page_url)
-        logging.info(HR)
+        logging.info(LINE_BREAK)
         while True:
             run_state = hook.get_run_state(run_id)
             if run_state.is_terminal:

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -22,7 +22,7 @@ class AirflowException(Exception):
 
 class AirflowConfigException(AirflowException):
     pass
-    
+
 
 class AirflowSensorTimeout(AirflowException):
     pass

--- a/airflow/models.py
+++ b/airflow/models.py
@@ -542,6 +542,7 @@ class Connection(Base):
         ('mesos_framework-id', 'Mesos Framework ID'),
         ('jira', 'JIRA',),
         ('redis', 'Redis',),
+        ('databricks', 'Databricks',),
     ]
 
     def __init__(

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -241,6 +241,10 @@ def initdb():
                     ]
                 }
             '''))
+    merge_conn(
+        models.Connection(
+            conn_id='databricks_default', conn_type='databricks',
+            host='localhost'))
 
     # Known event types
     KET = models.KnownEventType

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -91,7 +91,6 @@ Community-contributed Operators
 .. automodule:: airflow.contrib.operators
     :show-inheritance:
     :members:
-        DatabricksSubmitRunOperator,
         SSHExecuteOperator,
         VerticaOperator,
         VerticaToHiveTransfer
@@ -99,8 +98,6 @@ Community-contributed Operators
 .. autoclass:: airflow.contrib.operators.bigquery_operator.BigQueryOperator
 .. autoclass:: airflow.contrib.operators.bigquery_to_gcs.BigQueryToCloudStorageOperator
 .. autoclass:: airflow.contrib.operators.databricks_operator.DatabricksSubmitRunOperator
-    :members:
-        __init__
 .. autoclass:: airflow.contrib.operators.ecs_operator.ECSOperator
 .. autoclass:: airflow.contrib.operators.gcs_download_operator.GoogleCloudStorageDownloadOperator
 .. autoclass:: airflow.contrib.operators.QuboleOperator

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -91,12 +91,16 @@ Community-contributed Operators
 .. automodule:: airflow.contrib.operators
     :show-inheritance:
     :members:
+        DatabricksSubmitRunOperator,
         SSHExecuteOperator,
         VerticaOperator,
         VerticaToHiveTransfer
 
 .. autoclass:: airflow.contrib.operators.bigquery_operator.BigQueryOperator
 .. autoclass:: airflow.contrib.operators.bigquery_to_gcs.BigQueryToCloudStorageOperator
+.. autoclass:: airflow.contrib.operators.databricks_operator.DatabricksSubmitRunOperator
+    :members:
+        __init__
 .. autoclass:: airflow.contrib.operators.ecs_operator.ECSOperator
 .. autoclass:: airflow.contrib.operators.gcs_download_operator.GoogleCloudStorageDownloadOperator
 .. autoclass:: airflow.contrib.operators.QuboleOperator

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -15,7 +15,7 @@ AWS: Amazon Webservices
 
 Databricks
 --------------------------
-`Databricks <https://databricks.com/>`_ officially supports an Airflow operator which enables
+`Databricks <https://databricks.com/>`_ has contributed an Airflow operator which enables
 submitting runs to the Databricks platform. Internally the operator talks to the
 ``api/2.0/jobs/runs/submit`` `endpoint <https://docs.databricks.com/api/latest/jobs.html#runs-submit>`_.
 
@@ -23,8 +23,6 @@ DatabricksSubmitRunOperator
 ''''''''''''''''''''''''''''
 
 .. autoclass:: airflow.contrib.operators.databricks_operator.DatabricksSubmitRunOperator
-    :members:
-        __init__
 
 .. _GCP:
 

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -11,6 +11,21 @@ AWS: Amazon Webservices
 
 ---
 
+.. _Databricks:
+
+Databricks
+--------------------------
+`Databricks <https://databricks.com/>`_ officially supports an Airflow operator which enables
+submitting runs to the Databricks platform. Internally the operator talks to the
+``api/2.0/jobs/runs/submit`` `endpoint <https://docs.databricks.com/api/latest/jobs.html#runs-submit>`_.
+
+DatabricksSubmitRunOperator
+''''''''''''''''''''''''''''
+
+.. autoclass:: airflow.contrib.operators.databricks_operator.DatabricksSubmitRunOperator
+    :members:
+        __init__
+
 .. _GCP:
 
 GCP: Google Cloud Platform

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,7 @@ crypto = ['cryptography>=0.9.3']
 dask = [
     'distributed>=1.15.2, <2'
     ]
+databricks = ['requests>=2.5.1, <3']
 datadog = ['datadog>=0.14.0']
 doc = [
     'sphinx>=1.2.3',
@@ -241,6 +242,7 @@ def do_setup():
             'cloudant': cloudant,
             'crypto': crypto,
             'dask': dask,
+            'databricks': databricks,
             'datadog': datadog,
             'devel': devel_minreq,
             'devel_hadoop': devel_hadoop,

--- a/tests/contrib/hooks/databricks_hook.py
+++ b/tests/contrib/hooks/databricks_hook.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+from airflow import __version__
+from airflow.contrib.hooks.databricks_hook import DatabricksHook, RunState
+from airflow.models import Connection
+from airflow.utils import db
+
+TASK_ID = 'databricks-operator'
+DEFAULT_CONN_ID = 'databricks_default'
+NOTEBOOK_TASK = {
+    'notebook_path': '/test'
+}
+NEW_CLUSTER = {
+    'spark_version': '2.0.x-scala2.10',
+    'node_type_id': 'development-node',
+    'num_workers': 1
+}
+RUN_ID = 1
+HOST = 'databricks.com'
+LOGIN = 'login'
+PASSWORD = 'password'
+USER_AGENT_HEADER = {'user-agent': 'airflow-{v}'.format(v = __version__)}
+RUN_PAGE_URL = 'https://databricks.com/#jobs/1/runs/1'
+LIFE_CYCLE_STATE = 'PENDING'
+STATE_MESSAGE = 'Waiting for cluster'
+GET_RUN_RESPONSE = {
+    'run_page_url': RUN_PAGE_URL,
+    'state': {
+        'life_cycle_state': LIFE_CYCLE_STATE,
+        'state_message': STATE_MESSAGE
+    }
+}
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+def submit_run_endpoint(host):
+    return 'https://{}/api/2.0/jobs/runs/submit'.format(host)
+
+def get_run_endpoint(host):
+    return 'https://{}/api/2.0/jobs/runs/get'.format(host)
+
+class DatabricksHookTest(unittest.TestCase):
+
+    def setUp(self):
+        db.merge_conn(Connection(conn_id=DEFAULT_CONN_ID,
+                                 host=HOST,
+                                 login=LOGIN,
+                                 password=PASSWORD))
+        self.hook = DatabricksHook()
+
+    @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
+    def test_submit_run(self, mock_requests):
+        mock_requests.post.return_value.json.return_value = {'run_id': '1'}
+
+        run_id = self.hook.submit_run(notebook_task=NOTEBOOK_TASK,
+                                      new_cluster=NEW_CLUSTER)
+
+        self.assertEquals(run_id, '1')
+        mock_requests.post.assert_called_once_with(submit_run_endpoint(HOST),
+                                                  json={
+                                                      'notebook_task': NOTEBOOK_TASK,
+                                                      'new_cluster': NEW_CLUSTER,
+                                                      'libraries': [],
+                                                      'timeout_seconds': 0
+                                                  },
+                                                  auth=(LOGIN, PASSWORD),
+                                                  headers=USER_AGENT_HEADER,
+                                                  timeout=self.hook.timeout_seconds,
+                                                  verify=False)
+
+    @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
+    def test_get_run_page_url(self, mock_requests):
+        mock_requests.get.return_value.json.return_value = GET_RUN_RESPONSE
+
+        run_page_url = self.hook.get_run_page_url(RUN_ID)
+
+        self.assertEquals(run_page_url, RUN_PAGE_URL)
+        mock_requests.get.assert_called_once_with(get_run_endpoint(HOST),
+                                                  json={'run_id': RUN_ID},
+                                                  auth=(LOGIN, PASSWORD),
+                                                  headers=USER_AGENT_HEADER,
+                                                  timeout=self.hook.timeout_seconds,
+                                                  verify=False)
+
+    @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
+    def test_get_run_state(self, mock_requests):
+        mock_requests.get.return_value.json.return_value = GET_RUN_RESPONSE
+
+        run_state = self.hook.get_run_state(RUN_ID)
+
+        self.assertEquals(run_state, RunState.from_get_run_response(GET_RUN_RESPONSE))
+        mock_requests.get.assert_called_once_with(get_run_endpoint(HOST),
+                                                  json={'run_id': RUN_ID},
+                                                  auth=(LOGIN, PASSWORD),
+                                                  headers=USER_AGENT_HEADER,
+                                                  timeout=self.hook.timeout_seconds,
+                                                  verify=False)
+
+class RunStateTest(unittest.TestCase):
+    def test_from_get_run_response(self):
+        run_state = RunState.from_get_run_response(GET_RUN_RESPONSE)
+        self.assertEquals(run_state.state_message, STATE_MESSAGE)
+        self.assertEquals(run_state.life_cycle_state, LIFE_CYCLE_STATE)
+        self.assertEquals(run_state.result_state, None)
+
+    def test_is_terminal(self):
+        terminal_states = ['TERMINATED', 'SKIPPED', 'INTERNAL_ERROR']
+        for state in terminal_states:
+            run_state = RunState(state, '', '')
+            self.assertTrue(run_state.is_terminal)
+
+    def test_is_successful(self):
+        run_state = RunState('TERMINATED', 'SUCCESS', '')
+        self.assertTrue(run_state.is_successful)

--- a/tests/contrib/hooks/databricks_hook.py
+++ b/tests/contrib/hooks/databricks_hook.py
@@ -34,7 +34,7 @@ RUN_ID = 1
 HOST = 'databricks.com'
 LOGIN = 'login'
 PASSWORD = 'password'
-USER_AGENT_HEADER = {'user-agent': 'airflow-{v}'.format(v = __version__)}
+USER_AGENT_HEADER = {'user-agent': 'airflow-{v}'.format(v=__version__)}
 RUN_PAGE_URL = 'https://databricks.com/#jobs/1/runs/1'
 LIFE_CYCLE_STATE = 'PENDING'
 STATE_MESSAGE = 'Waiting for cluster'
@@ -54,11 +54,14 @@ except ImportError:
     except ImportError:
         mock = None
 
+
 def submit_run_endpoint(host):
     return 'https://{}/api/2.0/jobs/runs/submit'.format(host)
 
+
 def get_run_endpoint(host):
     return 'https://{}/api/2.0/jobs/runs/get'.format(host)
+
 
 class DatabricksHookTest(unittest.TestCase):
 
@@ -78,16 +81,16 @@ class DatabricksHookTest(unittest.TestCase):
 
         self.assertEquals(run_id, '1')
         mock_requests.post.assert_called_once_with(submit_run_endpoint(HOST),
-                                                  json={
+                                                   json={
                                                       'notebook_task': NOTEBOOK_TASK,
                                                       'new_cluster': NEW_CLUSTER,
                                                       'libraries': [],
                                                       'timeout_seconds': 0
-                                                  },
-                                                  auth=(LOGIN, PASSWORD),
-                                                  headers=USER_AGENT_HEADER,
-                                                  timeout=self.hook.timeout_seconds,
-                                                  verify=False)
+                                                   },
+                                                   auth=(LOGIN, PASSWORD),
+                                                   headers=USER_AGENT_HEADER,
+                                                   timeout=self.hook.timeout_seconds,
+                                                   verify=False)
 
     @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
     def test_get_run_page_url(self, mock_requests):
@@ -116,6 +119,7 @@ class DatabricksHookTest(unittest.TestCase):
                                                   headers=USER_AGENT_HEADER,
                                                   timeout=self.hook.timeout_seconds,
                                                   verify=False)
+
 
 class RunStateTest(unittest.TestCase):
     def test_from_get_run_response(self):

--- a/tests/contrib/hooks/databricks_hook.py
+++ b/tests/contrib/hooks/databricks_hook.py
@@ -80,8 +80,8 @@ class DatabricksHookTest(unittest.TestCase):
     @db.provide_session
     def setUp(self, session=None):
         conn = session.query(Connection) \
-                      .filter(Connection.conn_id == DEFAULT_CONN_ID) \
-                      .first()
+            .filter(Connection.conn_id == DEFAULT_CONN_ID) \
+            .first()
         conn.host = HOST
         conn.login = LOGIN
         conn.password = PASSWORD
@@ -114,21 +114,23 @@ class DatabricksHookTest(unittest.TestCase):
     def test_submit_run(self, mock_requests):
         mock_requests.post.return_value.json.return_value = {'run_id': '1'}
 
-        run_id = self.hook.submit_run(notebook_task=NOTEBOOK_TASK,
-                                      new_cluster=NEW_CLUSTER)
+        run_id = self.hook.submit_run(
+            notebook_task=NOTEBOOK_TASK,
+            new_cluster=NEW_CLUSTER)
 
         self.assertEquals(run_id, '1')
-        mock_requests.post.assert_called_once_with(submit_run_endpoint(HOST),
-                                                   json={
-                                                      'notebook_task': NOTEBOOK_TASK,
-                                                      'new_cluster': NEW_CLUSTER,
-                                                      'libraries': [],
-                                                      'timeout_seconds': 0
-                                                   },
-                                                   auth=(LOGIN, PASSWORD),
-                                                   headers=USER_AGENT_HEADER,
-                                                   timeout=self.hook.timeout_seconds,
-                                                   verify=False)
+        mock_requests.post.assert_called_once_with(
+            submit_run_endpoint(HOST),
+            json={
+                'notebook_task': NOTEBOOK_TASK,
+                'new_cluster': NEW_CLUSTER,
+                'libraries': [],
+                'timeout_seconds': 0
+            },
+            auth=(LOGIN, PASSWORD),
+            headers=USER_AGENT_HEADER,
+            timeout=self.hook.timeout_seconds,
+            verify=False)
 
     @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
     def test_get_run_page_url(self, mock_requests):
@@ -137,12 +139,13 @@ class DatabricksHookTest(unittest.TestCase):
         run_page_url = self.hook.get_run_page_url(RUN_ID)
 
         self.assertEquals(run_page_url, RUN_PAGE_URL)
-        mock_requests.get.assert_called_once_with(get_run_endpoint(HOST),
-                                                  json={'run_id': RUN_ID},
-                                                  auth=(LOGIN, PASSWORD),
-                                                  headers=USER_AGENT_HEADER,
-                                                  timeout=self.hook.timeout_seconds,
-                                                  verify=False)
+        mock_requests.get.assert_called_once_with(
+            get_run_endpoint(HOST),
+            json={'run_id': RUN_ID},
+            auth=(LOGIN, PASSWORD),
+            headers=USER_AGENT_HEADER,
+            timeout=self.hook.timeout_seconds,
+            verify=False)
 
     @mock.patch('airflow.contrib.hooks.databricks_hook.requests')
     def test_get_run_state(self, mock_requests):
@@ -151,12 +154,13 @@ class DatabricksHookTest(unittest.TestCase):
         run_state = self.hook.get_run_state(RUN_ID)
 
         self.assertEquals(run_state, RunState.from_get_run_response(GET_RUN_RESPONSE))
-        mock_requests.get.assert_called_once_with(get_run_endpoint(HOST),
-                                                  json={'run_id': RUN_ID},
-                                                  auth=(LOGIN, PASSWORD),
-                                                  headers=USER_AGENT_HEADER,
-                                                  timeout=self.hook.timeout_seconds,
-                                                  verify=False)
+        mock_requests.get.assert_called_once_with(
+            get_run_endpoint(HOST),
+            json={'run_id': RUN_ID},
+            auth=(LOGIN, PASSWORD),
+            headers=USER_AGENT_HEADER,
+            timeout=self.hook.timeout_seconds,
+            verify=False)
 
 
 class RunStateTest(unittest.TestCase):

--- a/tests/contrib/operators/databricks_operator.py
+++ b/tests/contrib/operators/databricks_operator.py
@@ -47,16 +47,17 @@ except ImportError:
 
 class DatabricksSubmitRunOperatorTest(unittest.TestCase):
 
-    def _test_init(self,
-                   op,
-                   expected_spark_jar_task,
-                   expected_notebook_task,
-                   expected_existing_cluster_id,
-                   expected_libraries,
-                   expected_run_name,
-                   expected_timeout_seconds,
-                   expected_extra_api_parameters,
-                   expected_databricks_conn_id):
+    def _test_init(
+            self,
+            op,
+            expected_spark_jar_task,
+            expected_notebook_task,
+            expected_existing_cluster_id,
+            expected_libraries,
+            expected_run_name,
+            expected_timeout_seconds,
+            expected_extra_api_parameters,
+            expected_databricks_conn_id):
         """
         Utility method to test behavior of initializer.
         """

--- a/tests/contrib/operators/databricks_operator.py
+++ b/tests/contrib/operators/databricks_operator.py
@@ -19,6 +19,14 @@ from airflow.contrib.hooks.databricks_hook import RunState
 from airflow.contrib.operators.databricks_operator import DatabricksSubmitRunOperator
 from airflow.exceptions import AirflowException
 
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
 TASK_ID = 'databricks-operator'
 DEFAULT_CONN_ID = 'databricks_default'
 NOTEBOOK_TASK = {
@@ -35,14 +43,6 @@ NEW_CLUSTER = {
 EXISTING_CLUSTER_ID = 'existing-cluster-id'
 RUN_NAME = 'run-name'
 RUN_ID = 1
-
-try:
-    from unittest import mock
-except ImportError:
-    try:
-        import mock
-    except ImportError:
-        mock = None
 
 
 class DatabricksSubmitRunOperatorTest(unittest.TestCase):

--- a/tests/contrib/operators/databricks_operator.py
+++ b/tests/contrib/operators/databricks_operator.py
@@ -44,6 +44,7 @@ except ImportError:
     except ImportError:
         mock = None
 
+
 class DatabricksSubmitRunOperatorTest(unittest.TestCase):
 
     def _test_init(self,
@@ -138,7 +139,7 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
                                          0,
                                          {},
                                          'databricks_default',
-                                         task_id = TASK_ID)
+                                         task_id=TASK_ID)
         self._test_init(op,
                         expected_spark_jar_task=None,
                         expected_notebook_task=NOTEBOOK_TASK,
@@ -161,7 +162,7 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
           'spark_jar_task': SPARK_JAR_TASK
         }
         with self.assertRaises(AirflowException):
-            op = DatabricksSubmitRunOperator(task_id=TASK_ID, **run)
+            DatabricksSubmitRunOperator(task_id=TASK_ID, **run)
 
     def test_init_with_invalid_oneof_cluster(self):
         """
@@ -175,7 +176,7 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
           'existing_cluster_id': EXISTING_CLUSTER_ID
         }
         with self.assertRaises(AirflowException):
-            op = DatabricksSubmitRunOperator(task_id=TASK_ID, **run)
+            DatabricksSubmitRunOperator(task_id=TASK_ID, **run)
 
     @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
     def test_exec_success(self, db_mock_class):
@@ -187,7 +188,6 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
           'notebook_task': NOTEBOOK_TASK,
         }
         op = DatabricksSubmitRunOperator(task_id=TASK_ID, **run)
-        attrs = {'method.return_value': 3, 'other.side_effect': KeyError}
         db_mock = db_mock_class.return_value
         db_mock.submit_run.return_value = 1
         db_mock.get_run_state.return_value = RunState('TERMINATED', 'SUCCESS', '')
@@ -195,13 +195,13 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
         op.execute(None)
 
         db_mock_class.assert_called_once_with(DEFAULT_CONN_ID)
-        db_mock.submit_run.assert_called_once_with(None,          # spark_jar_task
-                                                   NOTEBOOK_TASK, # notebook_task
-                                                   NEW_CLUSTER,   # new_cluster
-                                                   None,          # existing_cluster_id
-                                                   [],            # libraries
-                                                   TASK_ID,       # run_name
-                                                   0)             # timeout_seconds
+        db_mock.submit_run.assert_called_once_with(None,           # spark_jar_task
+                                                   NOTEBOOK_TASK,  # notebook_task
+                                                   NEW_CLUSTER,    # new_cluster
+                                                   None,           # existing_cluster_id
+                                                   [],             # libraries
+                                                   TASK_ID,        # run_name
+                                                   0)              # timeout_seconds
         db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
         db_mock.get_run_state.assert_called_once_with(RUN_ID)
 
@@ -214,8 +214,7 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
           'new_cluster': NEW_CLUSTER,
           'notebook_task': NOTEBOOK_TASK,
         }
-        op = DatabricksSubmitRunOperator(task_id = TASK_ID, **run)
-        attrs = {'method.return_value': 3, 'other.side_effect': KeyError}
+        op = DatabricksSubmitRunOperator(task_id=TASK_ID, **run)
         db_mock = db_mock_class.return_value
         db_mock.submit_run.return_value = 1
         db_mock.get_run_state.return_value = RunState('TERMINATED', 'SUCCESS', '')
@@ -223,13 +222,13 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
         op.execute(None)
 
         db_mock_class.assert_called_once_with(DEFAULT_CONN_ID)
-        db_mock.submit_run.assert_called_once_with(None,          # spark_jar_task
-                                                   NOTEBOOK_TASK, # notebook_task
-                                                   NEW_CLUSTER,   # new_cluster
-                                                   None,          # existing_cluster_id
-                                                   [],            # libraries
-                                                   TASK_ID,       # run_name
-                                                   0)             # timeout_seconds
+        db_mock.submit_run.assert_called_once_with(None,           # spark_jar_task
+                                                   NOTEBOOK_TASK,  # notebook_task
+                                                   NEW_CLUSTER,    # new_cluster
+                                                   None,           # existing_cluster_id
+                                                   [],             # libraries
+                                                   TASK_ID,        # run_name
+                                                   0)              # timeout_seconds
         db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
         db_mock.get_run_state.assert_called_once_with(RUN_ID)
 
@@ -244,7 +243,6 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
           'extra_api_parameters': {'test_param': '1'},
         }
         op = DatabricksSubmitRunOperator(task_id=TASK_ID, **run)
-        attrs = {'method.return_value': 3, 'other.side_effect': KeyError}
         db_mock = db_mock_class.return_value
         db_mock.submit_run.return_value = 1
         db_mock.get_run_state.return_value = RunState('TERMINATED', 'FAILED', '')
@@ -253,13 +251,13 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
             op.execute(None)
 
         db_mock_class.assert_called_once_with(DEFAULT_CONN_ID)
-        db_mock.submit_run.assert_called_once_with(None,          # spark_jar_task
-                                                   NOTEBOOK_TASK, # notebook_task
-                                                   NEW_CLUSTER,   # new_cluster
-                                                   None,          # existing_cluster_id
-                                                   [],            # libraries
-                                                   TASK_ID,       # run_name
-                                                   0,             # timeout_seconds
-                                                   test_param = '1')
+        db_mock.submit_run.assert_called_once_with(None,           # spark_jar_task
+                                                   NOTEBOOK_TASK,  # notebook_task
+                                                   NEW_CLUSTER,    # new_cluster
+                                                   None,           # existing_cluster_id
+                                                   [],             # libraries
+                                                   TASK_ID,        # run_name
+                                                   0,              # timeout_seconds
+                                                   test_param='1')
         db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
         db_mock.get_run_state.assert_called_once_with(RUN_ID)

--- a/tests/contrib/operators/databricks_operator.py
+++ b/tests/contrib/operators/databricks_operator.py
@@ -79,15 +79,16 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
           'notebook_task': NOTEBOOK_TASK
         }
         op = DatabricksSubmitRunOperator(task_id=TASK_ID, **run)
-        self._test_init(op,
-                        expected_spark_jar_task=None,
-                        expected_notebook_task=NOTEBOOK_TASK,
-                        expected_existing_cluster_id=None,
-                        expected_libraries=[],
-                        expected_run_name=TASK_ID,
-                        expected_timeout_seconds=0,
-                        expected_extra_api_parameters={},
-                        expected_databricks_conn_id=DEFAULT_CONN_ID)
+        self._test_init(
+            op,
+            expected_spark_jar_task=None,
+            expected_notebook_task=NOTEBOOK_TASK,
+            expected_existing_cluster_id=None,
+            expected_libraries=[],
+            expected_run_name=TASK_ID,
+            expected_timeout_seconds=0,
+            expected_extra_api_parameters={},
+            expected_databricks_conn_id=DEFAULT_CONN_ID)
 
     def test_init_with_unpacked_json_and_run_name(self):
         """
@@ -99,57 +100,62 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
           'run_name': RUN_NAME
         }
         op = DatabricksSubmitRunOperator(task_id=TASK_ID, **run)
-        self._test_init(op,
-                        expected_spark_jar_task=None,
-                        expected_notebook_task=NOTEBOOK_TASK,
-                        expected_existing_cluster_id=None,
-                        expected_libraries=[],
-                        expected_run_name=RUN_NAME,
-                        expected_timeout_seconds=0,
-                        expected_extra_api_parameters={},
-                        expected_databricks_conn_id=DEFAULT_CONN_ID)
+        self._test_init(
+            op,
+            expected_spark_jar_task=None,
+            expected_notebook_task=NOTEBOOK_TASK,
+            expected_existing_cluster_id=None,
+            expected_libraries=[],
+            expected_run_name=RUN_NAME,
+            expected_timeout_seconds=0,
+            expected_extra_api_parameters={},
+            expected_databricks_conn_id=DEFAULT_CONN_ID)
 
     def test_init_with_named_parameters(self):
         """
         Test the initializer which uses the named parameters.
         """
-        op = DatabricksSubmitRunOperator(task_id=TASK_ID,
-                                         new_cluster=NEW_CLUSTER,
-                                         notebook_task=NOTEBOOK_TASK)
-        self._test_init(op,
-                        expected_spark_jar_task=None,
-                        expected_notebook_task=NOTEBOOK_TASK,
-                        expected_existing_cluster_id=None,
-                        expected_libraries=[],
-                        expected_run_name=TASK_ID,
-                        expected_timeout_seconds=0,
-                        expected_extra_api_parameters={},
-                        expected_databricks_conn_id=DEFAULT_CONN_ID)
+        op = DatabricksSubmitRunOperator(
+            task_id=TASK_ID,
+            new_cluster=NEW_CLUSTER,
+            notebook_task=NOTEBOOK_TASK)
+        self._test_init(
+            op,
+            expected_spark_jar_task=None,
+            expected_notebook_task=NOTEBOOK_TASK,
+            expected_existing_cluster_id=None,
+            expected_libraries=[],
+            expected_run_name=TASK_ID,
+            expected_timeout_seconds=0,
+            expected_extra_api_parameters={},
+            expected_databricks_conn_id=DEFAULT_CONN_ID)
 
     def test_init_with_positional_parameters(self):
         """
         Test the initializer which uses positional parameters. Users should not
         use it this way but we cannot enforce this.
         """
-        op = DatabricksSubmitRunOperator(None,
-                                         NOTEBOOK_TASK,
-                                         NEW_CLUSTER,
-                                         None,
-                                         [],
-                                         None,
-                                         0,
-                                         {},
-                                         'databricks_default',
-                                         task_id=TASK_ID)
-        self._test_init(op,
-                        expected_spark_jar_task=None,
-                        expected_notebook_task=NOTEBOOK_TASK,
-                        expected_existing_cluster_id=None,
-                        expected_libraries=[],
-                        expected_run_name=TASK_ID,
-                        expected_timeout_seconds=0,
-                        expected_extra_api_parameters={},
-                        expected_databricks_conn_id=DEFAULT_CONN_ID)
+        op = DatabricksSubmitRunOperator(
+            None,
+            NOTEBOOK_TASK,
+            NEW_CLUSTER,
+            None,
+            [],
+            None,
+            0,
+            {},
+            'databricks_default',
+            task_id=TASK_ID)
+        self._test_init(
+            op,
+            expected_spark_jar_task=None,
+            expected_notebook_task=NOTEBOOK_TASK,
+            expected_existing_cluster_id=None,
+            expected_libraries=[],
+            expected_run_name=TASK_ID,
+            expected_timeout_seconds=0,
+            expected_extra_api_parameters={},
+            expected_databricks_conn_id=DEFAULT_CONN_ID)
 
     def test_init_with_invalid_oneof_task(self):
         """
@@ -196,13 +202,14 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
         op.execute(None)
 
         db_mock_class.assert_called_once_with(DEFAULT_CONN_ID)
-        db_mock.submit_run.assert_called_once_with(None,           # spark_jar_task
-                                                   NOTEBOOK_TASK,  # notebook_task
-                                                   NEW_CLUSTER,    # new_cluster
-                                                   None,           # existing_cluster_id
-                                                   [],             # libraries
-                                                   TASK_ID,        # run_name
-                                                   0)              # timeout_seconds
+        db_mock.submit_run.assert_called_once_with(
+            None,           # spark_jar_task
+            NOTEBOOK_TASK,  # notebook_task
+            NEW_CLUSTER,    # new_cluster
+            None,           # existing_cluster_id
+            [],             # libraries
+            TASK_ID,        # run_name
+            0)              # timeout_seconds
         db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
         db_mock.get_run_state.assert_called_once_with(RUN_ID)
 
@@ -223,13 +230,14 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
         op.execute(None)
 
         db_mock_class.assert_called_once_with(DEFAULT_CONN_ID)
-        db_mock.submit_run.assert_called_once_with(None,           # spark_jar_task
-                                                   NOTEBOOK_TASK,  # notebook_task
-                                                   NEW_CLUSTER,    # new_cluster
-                                                   None,           # existing_cluster_id
-                                                   [],             # libraries
-                                                   TASK_ID,        # run_name
-                                                   0)              # timeout_seconds
+        db_mock.submit_run.assert_called_once_with(
+            None,           # spark_jar_task
+            NOTEBOOK_TASK,  # notebook_task
+            NEW_CLUSTER,    # new_cluster
+            None,           # existing_cluster_id
+            [],             # libraries
+            TASK_ID,        # run_name
+            0)              # timeout_seconds
         db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
         db_mock.get_run_state.assert_called_once_with(RUN_ID)
 
@@ -252,13 +260,14 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
             op.execute(None)
 
         db_mock_class.assert_called_once_with(DEFAULT_CONN_ID)
-        db_mock.submit_run.assert_called_once_with(None,           # spark_jar_task
-                                                   NOTEBOOK_TASK,  # notebook_task
-                                                   NEW_CLUSTER,    # new_cluster
-                                                   None,           # existing_cluster_id
-                                                   [],             # libraries
-                                                   TASK_ID,        # run_name
-                                                   0,              # timeout_seconds
-                                                   test_param='1')
+        db_mock.submit_run.assert_called_once_with(
+            None,           # spark_jar_task
+            NOTEBOOK_TASK,  # notebook_task
+            NEW_CLUSTER,    # new_cluster
+            None,           # existing_cluster_id
+            [],             # libraries
+            TASK_ID,        # run_name
+            0,              # timeout_seconds
+            test_param='1')
         db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
         db_mock.get_run_state.assert_called_once_with(RUN_ID)

--- a/tests/contrib/operators/databricks_operator.py
+++ b/tests/contrib/operators/databricks_operator.py
@@ -1,0 +1,265 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+from airflow.contrib.hooks.databricks_hook import RunState
+from airflow.contrib.operators.databricks_operator import DatabricksSubmitRunOperator
+from airflow.exceptions import AirflowException
+
+TASK_ID = 'databricks-operator'
+DEFAULT_CONN_ID = 'databricks_default'
+NOTEBOOK_TASK = {
+    'notebook_path': '/test'
+}
+SPARK_JAR_TASK = {
+    'main_class_name': 'com.databricks.Test'
+}
+NEW_CLUSTER = {
+    'spark_version': '2.0.x-scala2.10',
+    'node_type_id': 'development-node',
+    'num_workers': 1
+}
+EXISTING_CLUSTER_ID = 'existing-cluster-id'
+RUN_NAME = 'run-name'
+RUN_ID = 1
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+class DatabricksSubmitRunOperatorTest(unittest.TestCase):
+
+    def _test_init(self,
+                   op,
+                   expected_spark_jar_task,
+                   expected_notebook_task,
+                   expected_existing_cluster_id,
+                   expected_libraries,
+                   expected_run_name,
+                   expected_timeout_seconds,
+                   expected_extra_api_parameters,
+                   expected_databricks_conn_id):
+        """
+        Utility method to test behavior of initializer.
+        """
+        self.assertEqual(op.spark_jar_task, expected_spark_jar_task)
+        self.assertEqual(op.notebook_task, expected_notebook_task)
+        self.assertEqual(op.existing_cluster_id, expected_existing_cluster_id)
+        self.assertEqual(op.libraries, expected_libraries)
+        self.assertEqual(op.run_name, expected_run_name)
+        self.assertEqual(op.timeout_seconds, expected_timeout_seconds)
+        self.assertEqual(op.extra_api_parameters, expected_extra_api_parameters)
+        self.assertEqual(op.databricks_conn_id, expected_databricks_conn_id)
+
+    def test_init_with_unpacked_json(self):
+        """
+        Test the initializer with a unpacked json data.
+        """
+        run = {
+          'new_cluster': NEW_CLUSTER,
+          'notebook_task': NOTEBOOK_TASK
+        }
+        op = DatabricksSubmitRunOperator(task_id=TASK_ID, **run)
+        self._test_init(op,
+                        expected_spark_jar_task=None,
+                        expected_notebook_task=NOTEBOOK_TASK,
+                        expected_existing_cluster_id=None,
+                        expected_libraries=[],
+                        expected_run_name=TASK_ID,
+                        expected_timeout_seconds=0,
+                        expected_extra_api_parameters={},
+                        expected_databricks_conn_id=DEFAULT_CONN_ID)
+
+    def test_init_with_unpacked_json_and_run_name(self):
+        """
+        Test the initializer with a unpacked json data and specified run_name.
+        """
+        run = {
+          'new_cluster': NEW_CLUSTER,
+          'notebook_task': NOTEBOOK_TASK,
+          'run_name': RUN_NAME
+        }
+        op = DatabricksSubmitRunOperator(task_id=TASK_ID, **run)
+        self._test_init(op,
+                        expected_spark_jar_task=None,
+                        expected_notebook_task=NOTEBOOK_TASK,
+                        expected_existing_cluster_id=None,
+                        expected_libraries=[],
+                        expected_run_name=RUN_NAME,
+                        expected_timeout_seconds=0,
+                        expected_extra_api_parameters={},
+                        expected_databricks_conn_id=DEFAULT_CONN_ID)
+
+    def test_init_with_named_parameters(self):
+        """
+        Test the initializer which uses the named parameters.
+        """
+        op = DatabricksSubmitRunOperator(task_id=TASK_ID,
+                                         new_cluster=NEW_CLUSTER,
+                                         notebook_task=NOTEBOOK_TASK)
+        self._test_init(op,
+                        expected_spark_jar_task=None,
+                        expected_notebook_task=NOTEBOOK_TASK,
+                        expected_existing_cluster_id=None,
+                        expected_libraries=[],
+                        expected_run_name=TASK_ID,
+                        expected_timeout_seconds=0,
+                        expected_extra_api_parameters={},
+                        expected_databricks_conn_id=DEFAULT_CONN_ID)
+
+    def test_init_with_positional_parameters(self):
+        """
+        Test the initializer which uses positional parameters. Users should not
+        use it this way but we cannot enforce this.
+        """
+        op = DatabricksSubmitRunOperator(None,
+                                         NOTEBOOK_TASK,
+                                         NEW_CLUSTER,
+                                         None,
+                                         [],
+                                         None,
+                                         0,
+                                         {},
+                                         'databricks_default',
+                                         task_id = TASK_ID)
+        self._test_init(op,
+                        expected_spark_jar_task=None,
+                        expected_notebook_task=NOTEBOOK_TASK,
+                        expected_existing_cluster_id=None,
+                        expected_libraries=[],
+                        expected_run_name=TASK_ID,
+                        expected_timeout_seconds=0,
+                        expected_extra_api_parameters={},
+                        expected_databricks_conn_id=DEFAULT_CONN_ID)
+
+    def test_init_with_invalid_oneof_task(self):
+        """
+        Test the initializer where notebook_task and spark_jar_task are
+        both specified. This is not allowed and an exception should
+        be raised.
+        """
+        run = {
+          'new_cluster': NEW_CLUSTER,
+          'notebook_task': NOTEBOOK_TASK,
+          'spark_jar_task': SPARK_JAR_TASK
+        }
+        with self.assertRaises(AirflowException):
+            op = DatabricksSubmitRunOperator(task_id=TASK_ID, **run)
+
+    def test_init_with_invalid_oneof_cluster(self):
+        """
+        Test the initializer where notebook_task and spark_jar_task are
+        both specified. This is not allowed and an exception should
+        be raised.
+        """
+        run = {
+          'new_cluster': NEW_CLUSTER,
+          'notebook_task': NOTEBOOK_TASK,
+          'existing_cluster_id': EXISTING_CLUSTER_ID
+        }
+        with self.assertRaises(AirflowException):
+            op = DatabricksSubmitRunOperator(task_id=TASK_ID, **run)
+
+    @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
+    def test_exec_success(self, db_mock_class):
+        """
+        Test the execute function in case where run is successful.
+        """
+        run = {
+          'new_cluster': NEW_CLUSTER,
+          'notebook_task': NOTEBOOK_TASK,
+        }
+        op = DatabricksSubmitRunOperator(task_id=TASK_ID, **run)
+        attrs = {'method.return_value': 3, 'other.side_effect': KeyError}
+        db_mock = db_mock_class.return_value
+        db_mock.submit_run.return_value = 1
+        db_mock.get_run_state.return_value = RunState('TERMINATED', 'SUCCESS', '')
+
+        op.execute(None)
+
+        db_mock_class.assert_called_once_with(DEFAULT_CONN_ID)
+        db_mock.submit_run.assert_called_once_with(None,          # spark_jar_task
+                                                   NOTEBOOK_TASK, # notebook_task
+                                                   NEW_CLUSTER,   # new_cluster
+                                                   None,          # existing_cluster_id
+                                                   [],            # libraries
+                                                   TASK_ID,       # run_name
+                                                   0)             # timeout_seconds
+        db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
+        db_mock.get_run_state.assert_called_once_with(RUN_ID)
+
+    @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
+    def test_exec_failure(self, db_mock_class):
+        """
+        Test the execute function in case where run is failed.
+        """
+        run = {
+          'new_cluster': NEW_CLUSTER,
+          'notebook_task': NOTEBOOK_TASK,
+        }
+        op = DatabricksSubmitRunOperator(task_id = TASK_ID, **run)
+        attrs = {'method.return_value': 3, 'other.side_effect': KeyError}
+        db_mock = db_mock_class.return_value
+        db_mock.submit_run.return_value = 1
+        db_mock.get_run_state.return_value = RunState('TERMINATED', 'SUCCESS', '')
+
+        op.execute(None)
+
+        db_mock_class.assert_called_once_with(DEFAULT_CONN_ID)
+        db_mock.submit_run.assert_called_once_with(None,          # spark_jar_task
+                                                   NOTEBOOK_TASK, # notebook_task
+                                                   NEW_CLUSTER,   # new_cluster
+                                                   None,          # existing_cluster_id
+                                                   [],            # libraries
+                                                   TASK_ID,       # run_name
+                                                   0)             # timeout_seconds
+        db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
+        db_mock.get_run_state.assert_called_once_with(RUN_ID)
+
+    @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
+    def test_exec_extra_param(self, db_mock_class):
+        """
+        Test the execute function in case where extra API parameters are used.
+        """
+        run = {
+          'new_cluster': NEW_CLUSTER,
+          'notebook_task': NOTEBOOK_TASK,
+          'extra_api_parameters': {'test_param': '1'},
+        }
+        op = DatabricksSubmitRunOperator(task_id=TASK_ID, **run)
+        attrs = {'method.return_value': 3, 'other.side_effect': KeyError}
+        db_mock = db_mock_class.return_value
+        db_mock.submit_run.return_value = 1
+        db_mock.get_run_state.return_value = RunState('TERMINATED', 'FAILED', '')
+
+        with self.assertRaises(AirflowException):
+            op.execute(None)
+
+        db_mock_class.assert_called_once_with(DEFAULT_CONN_ID)
+        db_mock.submit_run.assert_called_once_with(None,          # spark_jar_task
+                                                   NOTEBOOK_TASK, # notebook_task
+                                                   NEW_CLUSTER,   # new_cluster
+                                                   None,          # existing_cluster_id
+                                                   [],            # libraries
+                                                   TASK_ID,       # run_name
+                                                   0,             # timeout_seconds
+                                                   test_param = '1')
+        db_mock.get_run_page_url.assert_called_once_with(RUN_ID)
+        db_mock.get_run_state.assert_called_once_with(RUN_ID)

--- a/tests/contrib/operators/databricks_operator.py
+++ b/tests/contrib/operators/databricks_operator.py
@@ -181,7 +181,7 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
     @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
     def test_exec_success(self, db_mock_class):
         """
-        Test the execute function in case where run is successful.
+        Test the execute function in case where the run is successful.
         """
         run = {
           'new_cluster': NEW_CLUSTER,
@@ -208,7 +208,7 @@ class DatabricksSubmitRunOperatorTest(unittest.TestCase):
     @mock.patch('airflow.contrib.operators.databricks_operator.DatabricksHook')
     def test_exec_failure(self, db_mock_class):
         """
-        Test the execute function in case where run is failed.
+        Test the execute function in case where the run failed.
         """
         run = {
           'new_cluster': NEW_CLUSTER,

--- a/tests/core.py
+++ b/tests/core.py
@@ -1100,6 +1100,7 @@ class CliTests(unittest.TestCase):
         self.assertIn(['aws_default', 'aws'], conns)
         self.assertIn(['beeline_default', 'beeline'], conns)
         self.assertIn(['bigquery_default', 'bigquery'], conns)
+        self.assertIn(['databricks_default', 'databricks'], conns)
         self.assertIn(['emr_default', 'emr'], conns)
         self.assertIn(['mssql_default', 'mssql'], conns)
         self.assertIn(['mysql_default', 'mysql'], conns)


### PR DESCRIPTION
Dear Airflow maintainers,

Please accept this PR. I understand that it will not be reviewed until I have checked off all the steps below!


### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "[AIRFLOW-XXX] My Airflow PR"
    - https://issues.apache.org/jira/browse/AIRFLOW-XXX


### Description
- [ ] Here are some details about my PR, including screenshots of any UI changes:

Adds a DatabricksSubmitRunOperator which allows easy integration with Databricks.

### Tests
- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


### Manual Tests
- [ ] Test to see if USER_AGENT_HEADER can be retrieved
- [ ] Check with design about UI color.
- [x] Test to see if connections is robust to "https://" in the host name
- [x] Test to see if connections works normally with no "https://" in host name
- [ ] Check to see if our example works
### Commits
- [ ] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

### Documentation

https://airflow.incubator.apache.org/integration.html
![screen shot 2017-03-28 at 6 43 44 pm](https://cloud.githubusercontent.com/assets/4492809/24434799/95b0f298-13e6-11e7-87d0-627e3dc7181a.png)

------

https://airflow.incubator.apache.org/code.html#community-contributed-operators
![screen shot 2017-03-28 at 6 44 11 pm](https://cloud.githubusercontent.com/assets/4492809/24434802/970d8c46-13e6-11e7-8a7b-845c59fb1707.png)
